### PR TITLE
rory refactor submission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2429,7 +2429,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -9335,10 +9334,8 @@
             "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.1"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.1",
@@ -9400,7 +9397,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -9736,7 +9732,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",


### PR DESCRIPTION
Hi Glen!

Here's my crack at this problem-- I took the approach of trying to recreate the logic the browser uses to identify when text is bold and/or italic. I also loosened up the kinds of elements we're letting into this algorithm for analysis, and haven't run into anywhere that it bit me yet. I've gotten good results in the text I've tried, but I'm sure there are examples I missed.

The one known weirdness my refactored algorithm produces is that the JSON depth of 1 vs 2 "content" key is somewhat arbitrary when compared visually to the WYSIWYG input. Think:
`[{"content": [{ "style": "normal", "content": "Lorum." }, { "style": "normal", "content": "Ipsum." }] }]`
vs. 
`[{ "content": [{ "style": "normal", "content": "Lorum." }] }, { "content": [{ "style": "normal", "content": "Ipsum." }] }]`

It's not obvious which of these depths is preferable for what text input without us discussing it further, so I left it as-is for now.

Thanks for reviewing!
Rory